### PR TITLE
npm run start issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-scripts": "2.1.3"
   },
   "scripts": {
-    "start": "react-scripts --openssl-legacy-provider start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
**Issue**

While running command "npm start" after "npm install", instead of opening the browser at localhost:3000 ,the command prompt shows "node: bad option: --openssl-legacy-provider".

**Changes made**

In Package.json file 
`"start": "react-scripts --openssl-legacy-provider start"`  ->  `"start": "react-scripts start"`,